### PR TITLE
Fix build for zig 0.15

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,17 +31,16 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
-        .name = "libunistring",
+    const lib = b.addLibrary(.{ .name = "libunistring", .root_module = b.createModule(.{
         .target = target,
         .optimize = optimize,
-    });
+    }), .linkage = std.builtin.LinkMode.static });
     lib.linkLibC();
 
     const sources = switch (lib.rootModuleTarget().os.tag) {
         .macos => get_sources(sources_macos),
         else => switch (lib.rootModuleTarget().abi) {
-            .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnuf32, .gnuf64, .gnusf, .gnux32, .gnuilp32 => get_sources(sources_linux_gnu),
+            .gnu, .gnuabin32, .gnuabi64, .gnueabi, .gnueabihf, .gnuf32, .gnusf, .gnux32 => get_sources(sources_linux_gnu),
             .musl, .musleabi, .musleabihf, .muslx32 => get_sources(sources_linux_musl),
             else => get_sources(sources_linux_musl),
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "libunistring",
+    .name = .libunistring,
+    .fingerprint = 0xe601b539a507d757,
     .version = "1.1.0",
     .dependencies = .{},
     .paths = .{


### PR DESCRIPTION
Both .gnuf64 and .gnuilp32 are no longer present in the Abi enum provided by zig. I haven't researched this, if it is important to others I'm sure they will figure it out.

```
$ zig build
$ ar -t zig-out/lib/liblibunistring.a  | head
.zig-cache/o/fa1841ab75c527691a9d76ceb9165915/lock.o
.zig-cache/o/18798657fa303bb7e78636a2f8496254/threadlib.o
.zig-cache/o/b4e094f6656a83851815d72647c93663/amemxfrm.o
.zig-cache/o/60eb147a23f84c1116f8adf806febcd0/c-ctype.o
.zig-cache/o/d6df80446a5e5896026b209fb0c004a1/c-strcasecmp.o
.zig-cache/o/f0669b009406e906f1f5021bd8ea9738/c-strncasecmp.o
.zig-cache/o/18a3a21227cec192b24a60beca64d59e/fseterr.o
.zig-cache/o/667c8141efe95e07801791851cb08be4/hard-locale.o
.zig-cache/o/3e0d6ed27fac2ffdf8b94f82768ae587/localcharset.o
.zig-cache/o/e396b26500c8bb1ad8e63fa7e2719620/localename.o
```